### PR TITLE
Comments Fixed

### DIFF
--- a/app/src/main/java/com/example/qrranger/CommentCollection.java
+++ b/app/src/main/java/com/example/qrranger/CommentCollection.java
@@ -101,22 +101,15 @@ public class CommentCollection extends Database_Controls{
     /**
      * Deletes the specified document from the Firestore collection.
      *
-     * @param authorID The ID of the document to delete.
+     * @param docID The ID of the document to delete.
      */
     @Override
-    void delete(String authorID) {
-        Query query = collection.whereEqualTo("author_id", authorID);
-
-        query.get().addOnCompleteListener(task -> {
-            if (task.isSuccessful()) {
-                for (QueryDocumentSnapshot document : task.getResult()) {
-                    collection.document(document.getId()).delete();
-                }
-            } else {
-                System.out.println("Error deleting player: " + task.getException());
-            }
-        });
+    void delete(String docID) {
+        collection.document(docID).delete()
+                .addOnSuccessListener(aVoid -> System.out.println("Document successfully deleted!"))
+                .addOnFailureListener(e -> System.out.println("Error deleting document: " + e));
     }
+
 
 
     /**


### PR DESCRIPTION
The List Adapter would not set the QR ID and the Author ID when leaving and returning to the list, so deleting only worked while staying in the comments tab.
Adapter now properly sets all fields.
Delete now finds the comment based on author ID, QR ID, and the comment itself to get the DocID (comments don't have IDs themselves) since before it may have deleted multiple comments by the same user.
This finishes US 02.02.01:
As a player, I want to be able to comment on QR codes.

with the added ability of deleting a comment that you wrote